### PR TITLE
Stream Spotify API enrichment with DuckDB merge

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,5 @@ matplotlib
 seaborn
 streamlit
 altair
+duckdb
+psutil


### PR DESCRIPTION
## Summary
- stream API metadata batches directly to CSV and track progress in SQLite
- add DuckDB-based merge for streaming history join
- add CLI flag --merge-only and environment-aware configuration

## Testing
- `pip install duckdb psutil` *(fails: Could not find a version that satisfies the requirement duckdb)*
- `python -m py_compile scripts/spotify_api/smart_metadata_enrichment.py`
- `python scripts/spotify_api/smart_metadata_enrichment.py --merge-only` *(fails: ModuleNotFoundError: No module named 'duckdb')*


------
https://chatgpt.com/codex/tasks/task_e_689bea05d8f4832dbeefad036539f97f